### PR TITLE
Allow client middlewares to be customized

### DIFF
--- a/src/Admin/KeycloakClient.php
+++ b/src/Admin/KeycloakClient.php
@@ -299,6 +299,13 @@ class KeycloakClient extends GuzzleClient
         $stack = new HandlerStack();
         $stack->setHandler(new CurlHandler());
         $stack->push(new RefreshToken());
+        
+        $middlewares = isset($config["middlewares"]) && is_array($config["middlewares"]) ? $config["middlewares"] : [];
+        foreach ($middlewares as $middleware) {
+            if (is_callable($middleware)) {
+                $stack->push($middleware);
+            }
+        }
 
         $config['handler'] = $stack;
 


### PR DESCRIPTION
This change make it easier to customize the client middlewares by those using the library.

An example would be to throw exception on http status code 4xx and 5xx instead of returning an array with an "error" key (by using GuzzleHttp\Middleware::httpErrors() for example).