### PR TITLE
Feature token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,10 @@
 This is a php client to connect to keycloak admin rest apis with no headache.
 
 Features:
-
-1- Easy to use 
-
-2- No need to get token or generate it it's already handled by the client
-
-3- No need to specify any urls other than the base uri
-
-4- No encode/decode for json just data as you expect
+1. Easy to use
+2. No need to get token or generate it it's already handled by the client
+3. No need to specify any urls other than the base uri
+4. No encode/decode for json just data as you expect
 
 works with Keycloak 7.0 admin rest api
 
@@ -49,19 +45,20 @@ https://www.keycloak.org/docs-api/7.0/rest-api/index.html
 
 # How to use
 
-1- Create new client 
+#### 1. Create new client 
 
 ```php
 $client = Keycloak\Admin\KeycloakClient::factory([
-    'realm'=>'master',
-    'username'=>'admin',
-    'password'=>'1234',
-    'client_id'=>'admin-cli',
-    'baseUri'=>'http://127.0.0.1:8180'
-    ]);
+    'realm' => 'master',
+    'username' => 'admin',
+    'password' => '1234',
+    'client_id' => 'admin-cli',
+    'baseUri' => 'http://127.0.0.1:8180',
+]);
 ```
 
-2- Use it
+
+#### 2. Use it
 
 ```php
 $client->getUsers();
@@ -94,18 +91,46 @@ $client->getUsers();
 */
 
 $client->createUser([
-    'username'=>'test',
-    'email'=>'test@test.com',
-    'enabled'=>true,
-    'credentials'=>[
+    'username' => 'test',
+    'email' => 'test@test.com',
+    'enabled' => true,
+    'credentials' => [
         [
             'type'=>'password',
-            'value'=>'1234'
-        ]
-    ]
-    ]);
-
+            'value'=>'1234',
+        ],
+    ],
+]);
 ```
+
+# Customization
+
+### Supported credentials
+
+It is possible to change the credential's type used to authenticate by changing the configuration of the keycloak client.
+
+Currently, the following credentials are supported
+- password credentials, used by default
+  - to authenticate with a user account
+  ````php
+  $client = Keycloak\Admin\KeycloakClient::factory([
+    ...
+    'grant_type' => 'password',
+    'username' => 'admin',
+    'password' => '1234',
+  ]);
+  ````
+- client credentials
+  - to authenticate with a client service account
+  ````php
+  $client = Keycloak\Admin\KeycloakClient::factory([
+    ...
+    'grant_type' => 'client_credentials',
+    'client_id' => 'admin-cli',
+    'client_secret' => '84ab3d98-a0c3-44c7-b532-306f222ce1ff',
+  ]);
+  ````
+
 
 # Supported APIs
 

--- a/README.md
+++ b/README.md
@@ -114,23 +114,45 @@ Currently, the following credentials are supported
   - to authenticate with a user account
   ````php
   $client = Keycloak\Admin\KeycloakClient::factory([
-    ...
-    'grant_type' => 'password',
-    'username' => 'admin',
-    'password' => '1234',
+      ...
+      'grant_type' => 'password',
+      'username' => 'admin',
+      'password' => '1234',
   ]);
   ````
 - client credentials
   - to authenticate with a client service account
   ````php
   $client = Keycloak\Admin\KeycloakClient::factory([
-    ...
-    'grant_type' => 'client_credentials',
-    'client_id' => 'admin-cli',
-    'client_secret' => '84ab3d98-a0c3-44c7-b532-306f222ce1ff',
+      ...
+      'grant_type' => 'client_credentials',
+      'client_id' => 'admin-cli',
+      'client_secret' => '84ab3d98-a0c3-44c7-b532-306f222ce1ff',
   ]);
   ````
 
+### Injecting middleware
+
+It is possible to inject [Guzzle client middleware](https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html#middleware) 
+in the keycloak client configuration using the `middlewares` keyword.
+
+For example: 
+```php 
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
+
+$client = Keycloak\Admin\KeycloakClient::factory([
+    ...
+    'middlewares' => [
+        // throws exceptions when request fails
+        Middleware::httpErrors(),
+        // other custom middlewares
+        Middleware::mapRequest(function (RequestInterface $request) {
+            return $request;
+        }),
+    ],
+]);
+```
 
 # Supported APIs
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Introduction](#introduction)
 - [How to use](#how-to-use)
+- [Customization](#customization)
 - [Supported APIs](#supported-apis)
 	- [Attack Detection](#attack-detection)
 	- [Authentication Management](#authentication-management)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,33 @@ $client = Keycloak\Admin\KeycloakClient::factory([
 ]);
 ```
 
+### Changing how the token is saved and stored
+
+By default, the token is saved at runtime. This means that the previous token is not used when creating a new client.
+
+You can change customize how the token is stored in the client configuration by implementing your own `TokenStorage`, 
+an interface which describes how the token is stored and retrieved.
+```php 
+class CustomTokenStorage implements TokenStorage 
+{
+    public function getToken() 
+    {
+        // TODO
+    }
+    
+    public function saveToken(array $token)
+    {
+        // TODO
+    }
+}
+
+$client = Keycloak\Admin\KeycloakClient::factory([
+    ...
+    'token_storage' => new CustomTokenStorage(),
+]);
+```
+
+
 # Supported APIs
 
 ## [Attack Detection](https://www.keycloak.org/docs-api/7.0/rest-api/index.html#_attack_detection_resource)

--- a/src/Admin/KeycloakClient.php
+++ b/src/Admin/KeycloakClient.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use Keycloak\Admin\Classes\FullBodyLocation;
+use Keycloak\Admin\TokenStorages\RuntimeTokenStorage;
 
 /**
  * Class KeycloakClient
@@ -291,6 +292,7 @@ class KeycloakClient extends GuzzleClient
             'version'  => '1.0',
             'baseUri'  => null,
             'verify'   => true,
+            'token_storage' => new RuntimeTokenStorage(),
         );
 
         // Create client configuration
@@ -300,7 +302,6 @@ class KeycloakClient extends GuzzleClient
 
         $stack = new HandlerStack();
         $stack->setHandler(new CurlHandler());
-        $stack->push(new RefreshToken());
         
         $middlewares = isset($config["middlewares"]) && is_array($config["middlewares"]) ? $config["middlewares"] : [];
         foreach ($middlewares as $middleware) {
@@ -308,6 +309,8 @@ class KeycloakClient extends GuzzleClient
                 $stack->push($middleware);
             }
         }
+
+        $stack->push(new RefreshToken($config['token_storage']));
 
         $config['handler'] = $stack;
 

--- a/src/Admin/TokenStorages/ChainedTokenStorage.php
+++ b/src/Admin/TokenStorages/ChainedTokenStorage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Keycloak\Admin\TokenStorages;
+
+class ChainedTokenStorage implements TokenStorage
+{
+    /**
+     * @var array|TokenStorage[]
+     */
+    private $storages;
+
+    public function __construct(TokenStorage ...$storages)
+    {
+        $this->storages = $storages;
+    }
+
+    public function getToken()
+    {
+        foreach ($this->storages as $storage) {
+            $token = $storage->getToken();
+            if ($token) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
+    public function saveToken(array $token)
+    {
+        foreach ($this->storages as $storage) {
+            $storage->saveToken($token);
+        }
+    }
+}

--- a/src/Admin/TokenStorages/RuntimeTokenStorage.php
+++ b/src/Admin/TokenStorages/RuntimeTokenStorage.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Keycloak\Admin\TokenStorages;
+
+class RuntimeTokenStorage implements TokenStorage
+{
+    /**
+     * @var ?array
+     */
+    private $token = null;
+
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    public function saveToken(array $token)
+    {
+        $this->token = $token;
+    }
+}

--- a/src/Admin/TokenStorages/TokenStorage.php
+++ b/src/Admin/TokenStorages/TokenStorage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Keycloak\Admin\TokenStorages;
+
+interface TokenStorage
+{
+    /**
+     * @return array|null
+     */
+    public function getToken();
+
+    /**
+     * @param array $token
+     */
+    public function saveToken(array $token);
+}


### PR DESCRIPTION
This pr 
- adds a way to customize how the token is stored
    - for instance, saving the token into a file, or in redis
    -  this allows to use the same token between different php processes (without, the token is lost when the `KeycloakClient` is re-created)
- moves the RefreshToken middleware as the last middleware
    - by putting the RefreshToken middleware in the last position, the token will be refreshed when middlewares like `Middleware::retry` are used 
- adds some documentation in the readme regarding the configuration