### PR TITLE
Add exact parameter for getUsers endpoint

### DIFF
--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -5090,6 +5090,12 @@ return array(
                     'type'        => 'string',
                     'required'    => false,
                 ),
+                'exact' => array(
+                    'location'    => 'query',
+                    'type'        => 'string',
+                    'required'    => false,
+                    'enum'        => ['true', 'false'],
+                ),
                 'first' => array(
                     'location'    => 'query',
                     'type'        => 'integer',
@@ -5121,7 +5127,7 @@ return array(
                     'location'    => 'query',
                     'type'        => 'string',
                     'required'    => false,
-                )
+                ),
             ),
         ),
 


### PR DESCRIPTION
Enables `exact` parameter to be passed into the `getUser` method as a key and returns only one exact result instead of many similar:

```php
$keycloakClient = factory([KeycloakClientAdmin::class, 'factory'])->parameter('config', [
        'realm' => getenv('KEYCLOAK_REALM'),
        'username' => getenv('KEYCLOAK_USERNAME'),
        'password' => getenv('KEYCLOAK_PASSWORD'),
        'client_id' => getenv('KEYCLOAK_CLIENT_ID'),
        'baseUri' => getenv('KEYCLOAK_BASE_URI'),
    ]);
 $response = $keycloakClient->getUsers([
    'username' => 'username',
    'exact' => 'true',
]);
```

Also resolves https://github.com/MohammadWaleed/keycloak-admin-client/issues/76