### PR TITLE
make it possible to extend the KeycloakClient

### DIFF
--- a/src/Admin/KeycloakClient.php
+++ b/src/Admin/KeycloakClient.php
@@ -329,7 +329,7 @@ class KeycloakClient extends GuzzleClient
         $description = new Description($serviceDescription);
 
         // Create the new Keycloak Client with our Configuration
-        return new self(
+        return new static(
             new Client($config),
             $description,
             new Serializer($description, [


### PR DESCRIPTION
to do so, suggesting the `factory` method should create a `new static` instead of a `new self`

otherwise, when extending `KeycloakClient`, the parent class gets instantiated instead of the expected child class