### PR TITLE
Fixed service definition of createChildGroup, remove name clash of id

### DIFF
--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -2334,7 +2334,7 @@ return array(
         ),
 
         'createChildGroup' => array(
-            'uri'         => 'admin/realms/{realm}/groups/{id}/children',
+            'uri'         => 'admin/realms/{realm}/groups/{groupId}/children',
             'description' => 'Set or create child.',
             'httpMethod'  => 'POST',
             'parameters'  => array(
@@ -2344,7 +2344,7 @@ return array(
                     'type'        => 'string',
                     'required'    => true,
                 ),
-                'id' => array(
+                'groupId' => array(
                     'location'    => 'uri',
                     'description' => 'Group id',
                     'type'        => 'string',


### PR DESCRIPTION
For the createChildGroup function, the id parameter is defined in the url (to address to group to be updated) and also in the body (to address the child group to be assigned).

This change breaks compatibility, as it renames the url parameter.
