### PR TITLE
prepare for 0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,12 @@ Note: Ids are sent as clientScopeId or clientId and mapperId everything else is 
 | Get the events provider configuration Returns JSON object with events provider configuration                                                      |         getEventsConfig         |    ✔️     |
 | Update the events provider Change the events provider and/or its configuration                                                                    |       updateEventsConfig        |    ✔️     |
 | Get user group by path                                                                                                                            |         getGroupByPath          |    ✔️     |
+| GET /{realm}/localization                                                                                                                         |     getLocalizationLocales      |    ✔️     |
+| POST /{realm}/localization/{locale}                                                                                                               |     updateLocalizationTexts     |    ✔️     |
+| GET /{realm}/localization/{locale}                                                                                                                |       getLocalizationTexts      |    ✔️     |
+| DELETE /{realm}/localization/{locale}                                                                                                             |     deleteLocalizationTexts     |    ✔️     |
+| GET /{realm}/localization/{locale}/{key}                                                                                                          |       getLocalizationText       |    ✔️     |
+| PUT /{realm}/localization/{locale}/{key}                                                                                                          |       saveLocalizationText      |    ✔️     |
 | Removes all user sessions. (Keycloak throws an exception when this one is called)                                                                 |         logoutAllUsers          |     ❌     |
 | Partial export of existing realm into a JSON file.                                                                                                |       partialExportRealm        |    ✔️     |
 | Partial import from a JSON file to an existing realm.                                                                                             |       partialImportRealm        |    ✔️     |

--- a/README.md
+++ b/README.md
@@ -587,21 +587,21 @@ Note: Ids are sent as clientScopeId or clientId and mapperId everything else is 
 | Revoke consent and offline tokens for particular client from user                                                                                                  |                     |     ❌     |
 | Disable all credentials for a user of a specific type                                                                                                              |                     |     ❌     |
 | Send a update account email to the user An email contains a link the user can click to perform a set of required actions.                                          | executeActionsEmail |    ✔️     |
-| Get social logins associated with the user                                                                                                                         |                     |     ✔     |
-| Add a social login provider to the user                                                                                                                            |                     |     ✔     |
-| Remove a social login provider from user                                                                                                                           |                     |     ✔     |
+| Get social logins associated with the user                                                                                                                         |                     |    ✔️     |
+| Add a social login provider to the user                                                                                                                            |                     |    ✔️     |
+| Remove a social login provider from user                                                                                                                           |                     |    ✔️     |
 | GET /{realm}/users/{id}/groups                                                                                                                                     |    getUserGroups    |    ✔️     |
 | GET /{realm}/users/{id}/groups/count                                                                                                                               | getUserGroupsCount  |    ✔️     |
 | PUT /{realm}/users/{id}/groups/{groupId}                                                                                                                           |   addUserToGroup    |    ✔️     | 
 | DELETE /{realm}/users/{id}/groups/{groupId}                                                                                                                        | deleteUserFromGroup |    ✔️     |
-| Impersonate the user                                                                                                                                               |                     |     ❌     |
-| Remove all user sessions associated with the user Also send notification to all clients that have an admin URL to invalidate the sessions for the particular user. |                     |     ❌     |
+| Impersonate the user                                                                                                                                               |   impersonateUser   |    ✔️     |
+| Remove all user sessions associated with the user Also send notification to all clients that have an admin URL to invalidate the sessions for the particular user. |     logoutUser      |    ✔️     |
 | Get offline sessions associated with the user and client                                                                                                           |                     |     ❌     |
 | Remove TOTP from the user                                                                                                                                          |                     |     ❌     |
 | Set up a new password for the user.                                                                                                                                |  resetUserPassword  |    ✔️     |
 | Send an email-verification email to the user An email contains a link the user can click to verify their email address.                                            |   sendVerifyEmail   |    ✔️     |
-| Get sessions associated with the user                                                                                                                              |   getUserSessions   |     ✔     |
-| Get credentials associated with the user                                                                                                                           |   getUserCredentials  |     ✔     |
+| Get sessions associated with the user                                                                                                                              |   getUserSessions   |    ✔️     |
+| Get credentials associated with the user                                                                                                                           | getUserCredentials  |    ✔️     |
 
  ## [Root]()
 

--- a/src/Admin/Classes/FullTextLocation.php
+++ b/src/Admin/Classes/FullTextLocation.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Keycloak\Admin\Classes;
+
+use GuzzleHttp\Command\CommandInterface;
+use GuzzleHttp\Command\Guzzle\Parameter;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Command\Guzzle\RequestLocation\AbstractLocation;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Adds a raw text body to a request
+ */
+class FullTextLocation extends AbstractLocation
+{
+    /**
+     * @var string Whether or not to add Content-Type header
+     */
+    private $contentType;
+
+    /**
+     * @param string $locationName Name of the location
+     * @param string $contentType Content-Type header to add to the request.
+     *     Pass an empty string to omit.
+     */
+    public function __construct($locationName = 'fulltext', $contentType = 'text/plain')
+    {
+        parent::__construct($locationName);
+        $this->contentType = $contentType;
+    }
+
+    /**
+     * @param CommandInterface $command
+     * @param RequestInterface $request
+     * @param Parameter        $param
+     *
+     * @return MessageInterface
+     */
+    public function visit(
+        CommandInterface $command,
+        RequestInterface $request,
+        Parameter $param
+    ) {
+        $oldValue = $request->getBody()->getContents();
+
+        $value = $command[$param->getName()];
+        $value = $param->filter($value);
+
+        if ($oldValue !== '') {
+            $value = $oldValue.$vaule;
+        }
+
+        if ($this->contentType && !$request->hasHeader('Content-Type')) {
+            $request = $request->withHeader('Content-Type', $this->contentType);
+        }
+
+        return $request->withBody(Psr7\Utils::streamFor($value));
+    }
+}

--- a/src/Admin/KeycloakClient.php
+++ b/src/Admin/KeycloakClient.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use Keycloak\Admin\Classes\FullBodyLocation;
+use Keycloak\Admin\Classes\FullTextLocation;
 use Keycloak\Admin\TokenStorages\RuntimeTokenStorage;
 
 /**
@@ -193,6 +194,13 @@ use Keycloak\Admin\TokenStorages\RuntimeTokenStorage;
  * @method array getEventsConfig(array $args = array()) { @command Keycloak getEventsConfig }
  * @method array updateEventsConfig(array $args = array()) { @command Keycloak updateEventsConfig }
  * @method array getGroupByPath(array $args = array()) { @command Keycloak getGroupByPath }
+ * @method array getLocalizationLocales(array $args = array()) { @command Keycloak getLocalizationLocales }
+ * @method array getLocalizationTexts(array $args = array()) { @command Keycloak getLocalizationTexts }
+ * @method array updateLocalizationTexts(array $args = array()) { @command Keycloak updateLocalizationTexts }
+ * @method array deleteLocalizationTexts(array $args = array()) { @command Keycloak deleteLocalizationTexts }
+ * @method array getLocalizationText(array $args = array()) { @command Keycloak getLocalizationText }
+ * @method array saveLocalizationText(array $args = array()) { @command Keycloak saveLocalizationText }
+ * @method array deleteLocalizationText(array $args = array()) { @command Keycloak deleteLocalizationText }
  * @method array logoutAllUsers(array $args = array()) { @command Keycloak logoutAllUsers }
  * @method array partialExportRealm(array $args = array()) { @command Keycloak partialExportRealm }
  * @method array partialImportRealm(array $args = array()) { @command Keycloak partialImportRealm }
@@ -339,7 +347,8 @@ class KeycloakClient extends GuzzleClient
             new Client($config),
             $description,
             new Serializer($description, [
-                "fullBody" => new FullBodyLocation()
+                "fullBody" => new FullBodyLocation(),
+                "fullText" => new FullTextLocation(),
             ]),
             function ($response) {
                 $responseBody = $response->getBody()->getContents();

--- a/src/Admin/KeycloakClient.php
+++ b/src/Admin/KeycloakClient.php
@@ -271,14 +271,15 @@ use Keycloak\Admin\TokenStorages\RuntimeTokenStorage;
  * @method array resetUserPassword(array $args = array()) { @command Keycloak resetUserPassword }
  * @method array getUserSessions(array $args = array()) { @command Keycloak getUserSessions }
  * @method array getUserCredentials(array $args = array()) { @command Keycloak getUserCredentials }
- *
- * @method array syncUserStorage(array $args = array()) { @command Keycloak syncUserStorage }
+ * @method array impersonateUser(array $args = array()) { @command Keycloak impersonateUser }
+ * @method array logoutUser(array $args = array()) { @command Keycloak logoutUser }
  *
  * @method array getSocialLogins(array $args = array()) { @command Keycloak getSocialLogins }
  * @method array addSocialLogin(array $args = array()) { @command Keycloak addSocialLogin }
  * @method array removeSocialLogin(array $args = array()) { @command Keycloak removeSocialLogin }
+ * @method array syncUserStorage(array $args = array()) { @command Keycloak syncUserStorage }
  * @method array getUserConsents(array $args = array()) { @command Keycloak getUserConsents }
- * 
+ *
  */
 
 class KeycloakClient extends GuzzleClient
@@ -310,7 +311,7 @@ class KeycloakClient extends GuzzleClient
 
         $stack = new HandlerStack();
         $stack->setHandler(new CurlHandler());
-        
+
         $middlewares = isset($config["middlewares"]) && is_array($config["middlewares"]) ? $config["middlewares"] : [];
         foreach ($middlewares as $middleware) {
             if (is_callable($middleware)) {

--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -3652,6 +3652,175 @@ return array(
             )
         ),
 
+        'getLocalizationLocales' => array(
+            'uri'         => 'admin/realms/{realm}/localization',
+            'description' => 'Get localization locales for realm',
+            'httpMethod'  => 'GET',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+            )
+        ),
+
+        'getLocalizationTexts' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}',
+            'description' => 'Get localization texts for a realm locale',
+            'httpMethod'  => 'GET',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'useRealmDefaultLocaleFallback' => array(
+                    'location'    => 'query',
+                    'description' => 'Fallback to realm default locale',
+                    'type'        => 'string',
+                    'required'    => false,
+                ),
+            )
+        ),
+
+        'updateLocalizationTexts' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}',
+            'description' => 'Update localization texts for a realm locale',
+            'httpMethod'  => 'POST',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'localizationTexts' => array(
+                    'location' => 'fullBody',
+                    'description' => 'Map of text values for the locale',
+                    'required' => true
+                ),
+            )
+        ),
+
+        'deleteLocalizationTexts' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}',
+            'description' => 'Update localization texts for a realm locale',
+            'httpMethod'  => 'DELETE',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+            )
+        ),
+
+        'getLocalizationText' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}/{key}',
+            'description' => 'Get a localization text for a realm locale',
+            'httpMethod'  => 'GET',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'key' => array(
+                    'location'    => 'uri',
+                    'description' => 'The text key name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+            )
+        ),
+
+        'saveLocalizationText' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}/{key}',
+            'description' => 'Set a localization text for a realm locale',
+            'httpMethod'  => 'PUT',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'key' => array(
+                    'location'    => 'uri',
+                    'description' => 'The text key name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'text' => array(
+                    'location'    => 'fullText',
+                    'description' => 'The text value',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+            )
+        ),
+
+        'deleteLocalizationText' => array(
+            'uri'         => 'admin/realms/{realm}/localization/{locale}/{key}',
+            'description' => 'Delete a localization text for a realm locale',
+            'httpMethod'  => 'DELETE',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'locale' => array(
+                    'location'    => 'uri',
+                    'description' => 'The locale name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'key' => array(
+                    'location'    => 'uri',
+                    'description' => 'The text key name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+            )
+        ),
+
         'logoutAllUsers' => array(
             'uri'         => 'admin/realms/{realm}/logout-all',
             'description' => 'Removes all user sessions.',

--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -5299,7 +5299,7 @@ return array(
                 ),
             ),
         ),
-        
+
         'sendVerifyEmail' => array(
             'uri' => 'admin/realms/{realm}/users/{id}/send-verify-email',
             'description' => 'Send an email-verification email to the user An email contains a link the user can click to verify their email address.',
@@ -5469,6 +5469,7 @@ return array(
                 )
             )
         ),
+
         'getSocialLogins' => array(
             'uri'         => 'admin/realms/{realm}/users/{id}/federated-identity',
             'description' => 'Get social logins associated with the user',
@@ -5488,6 +5489,7 @@ return array(
                 ),
             )
         ),
+
         'removeSocialLogin' => array(
             'uri'         => 'admin/realms/{realm}/users/{id}/federated-identity/{providerId}',
             'description' => 'Remove social login associated with the user',
@@ -5513,6 +5515,7 @@ return array(
                 ),
             )
         ),
+
         'addSocialLogin' => array(
             'uri'         => 'admin/realms/{realm}/users/{id}/federated-identity/{providerId}',
             'description' => 'Add social login associated with the user',
@@ -5538,5 +5541,46 @@ return array(
                     ),
                 ) + $FederatedIdentityRepresentation,
         ),
+
+        'impersonateUser' => array(
+            'uri'         => 'admin/realms/{realm}/users/{id}/impersonation',
+            'description' => 'Remove all sessions associated with the user',
+            'httpMethod'  => 'POST',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'id' => array(
+                    'location' => 'uri',
+                    'description' => 'User id',
+                    'type' => 'string',
+                    'required' => true
+                )
+            )
+        ),
+
+        'logoutUser' => array(
+            'uri'         => 'admin/realms/{realm}/users/{id}/logout',
+            'description' => 'Remove all sessions associated with the user',
+            'httpMethod'  => 'POST',
+            'parameters'  => array(
+                'realm' => array(
+                    'location'    => 'uri',
+                    'description' => 'The Realm name',
+                    'type'        => 'string',
+                    'required'    => true,
+                ),
+                'id' => array(
+                    'location' => 'uri',
+                    'description' => 'User id',
+                    'type' => 'string',
+                    'required' => true
+                )
+            )
+        ),
+
     ) //End of Operations Array
 );//End of return array


### PR DESCRIPTION
Add commands for Realm localization routes: by @leyarotheconquerer 
https://www.keycloak.org/docs-api/21.0.1/rest-api/index.html#_getrealmlocalizationlocales

Adds a FullTextLocation class in order to pass the given value to the server verbatim.

The Keycloak API expects a text/plain HTTP request for the PUT /{realm}/localization/{locale}/{key} request. All other locations targeting the body cause the content to be encoded, corrupting the value passed in by the user.

FullTextLocation provides a way to pass the parameter unaltered to the API. If you have alternate suggestions for how to accomplish this, I'd be happy to refactor the code.

It also follows the FullBodyLocation by setting the Content-Type header to 'text/plain' if it isn't set elsewhere.