### PR TITLE
Add missing "attributes" parameter for getGroups, getUserCount and ge…

### DIFF
--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -1417,7 +1417,13 @@ return array(
                     'description' => 'filter clients that cannot be viewed in full by admin',
                     'type'        => 'boolean',
                     'required'    => false,
-                )
+                ),
+                'q' => array(
+                    'location'    => 'query',
+                    'description' => 'A query to search for custom attributes, in the format \'key1:value2 key2:value2\'',
+                    'type'        => 'string',
+                    'required'    => false,
+                ),
             ),
         ),
 
@@ -2241,6 +2247,12 @@ return array(
                 'search' => array(
                     'location'    => 'query',
                     'description' => 'search string',
+                    'type'        => 'string',
+                    'required'    => false,
+                ),
+                'q' => array(
+                    'location'    => 'query',
+                    'description' => 'A query to search for custom attributes, in the format \'key1:value2 key2:value2\'',
                     'type'        => 'string',
                     'required'    => false,
                 ),
@@ -5234,7 +5246,13 @@ return array(
                     'location'    => 'query',
                     'type'        => 'string',
                     'required'    => false,
-                )
+                ),
+                'q' => array(
+                    'location'    => 'query',
+                    'description' => 'A query to search for custom attributes, in the format \'key1:value2 key2:value2\'',
+                    'type'        => 'string',
+                    'required'    => false,
+                ),
             ),
         ),
 


### PR DESCRIPTION
I had issues filtering groups by the attributes parameter and noticed it was missing in the definition. For now I override it locally with the custom_operations option for the client. This PR fixes al the operations where filtering on attributes is possible. See:

https://www.keycloak.org/docs-api/22.0.1/rest-api/index.html