### PR TITLE
Allow reserved uri characters in group by path query

### DIFF
--- a/src/Admin/Resources/keycloak-1_0.php
+++ b/src/Admin/Resources/keycloak-1_0.php
@@ -3633,7 +3633,7 @@ return array(
         ),
 
         'getGroupByPath' => array(
-            'uri'         => 'admin/realms/{realm}/group-by-path/{path}',
+            'uri'         => 'admin/realms/{realm}/group-by-path/{+path}',
             'description' => 'Get user group by path',
             'httpMethod'  => 'GET',
             'parameters'  => array(


### PR DESCRIPTION
As mentioned in #112 by @micbis it's currently not possible to get groups for nested paths. By prefixing the template variable with a plus operator `{+path}` reserved uri characters are allowed and will not be encoded.
https://datatracker.ietf.org/doc/html/rfc6570#section-1.2